### PR TITLE
[rpm-ostree] Install NVIDIA drivers

### DIFF
--- a/rpm-ostree/playtron-dev-os.yaml
+++ b/rpm-ostree/playtron-dev-os.yaml
@@ -12,6 +12,15 @@ packages:
   - playtron-os-scripts
   ## Mesa is already pulled in as part of the Fedora Silverblue configuration.
   #- mesa
+  # NVIDIA package for the Playtron OS kernel.
+  - kmod-nvidia-535.54.03-6.3.13-200.playtron.x86_64
+  ## These come from the "nvidia-driver" module stream.
+  - nvidia-driver
+  - nvidia-driver-cuda
+modules:
+  enable:
+    - nvidia-driver:latest-dkms
 repos:
   - playtron-gaming-x86_64
   - playtron-gaming-i386
+  - playtron-nvidia-x86_64

--- a/rpm-ostree/playtron-nvidia-x86_64.repo
+++ b/rpm-ostree/playtron-nvidia-x86_64.repo
@@ -1,0 +1,9 @@
+[playtron-nvidia-x86_64]
+name=NVIDIA repository for Playtron OS
+baseurl=https://playtron-dev-global-os-public.s3.us-west-2.amazonaws.com/repos/playtron-nvidia/x86_64/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1


### PR DESCRIPTION
These NVIDIA drivers are pre-built against the Playtron OS kernel.