### PR TITLE
go back to using default gamescope

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -17,7 +17,6 @@ packages:
   # Used for authenticating with Epic Games.
   - legendary
   # Packages from the playtron-gaming repository:
-  - gamescope-plus
   - gamescope-session-playtron
   - playtron-os-scripts
   - udev-media-automount
@@ -61,8 +60,6 @@ packages:
   - lsb_release
   # for dev/debug mode session
   - weston
-exclude-packages:
-  - gamescope
 repos:
   - fedora-38
   - fedora-38-updates


### PR DESCRIPTION
Now that Playtron app can handle volume keys, we no longer need the gamescope fork with hacked volume key support. In fact, we cannot use the gamescope fork because it will prevent Playtron app from being able to natively handle the volume keys.