### PR TITLE
bump image size so that build succeeds

### DIFF
--- a/kickstart/virt-install.sh
+++ b/kickstart/virt-install.sh
@@ -7,7 +7,7 @@ sudo virt-install \
   --os-variant fedora38 \
   --boot uefi \
   --vcpus 4 --ram 16384 \
-  --disk=/var/lib/libvirt/images/playtron-os.img,bus=virtio,format=raw,size=8 \
+  --disk=/var/lib/libvirt/images/playtron-os.img,bus=virtio,format=raw,size=9 \
   --location=https://mirror.rackspace.com/fedora/releases/38/Everything/x86_64/os/ \
   --initrd-inject ./playtron-os_kickstart.cfg \
   --extra-args="inst.ks=file:/playtron-os_kickstart.cfg net.ifnames=0 biosdevname=0" \


### PR DESCRIPTION
Building the OS installer image was failing due to a "no space left on device" error. Bumping the image size fixed the issue.