### PR TITLE
[kickstart] Add back getaddrinfo config

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg
+++ b/kickstart/playtron-os_kickstart.cfg
@@ -111,7 +111,8 @@ icon=/usr/share/icons/Adwaita/16x16/mimetypes/application-x-executable.png
 path=/usr/bin/playtron-labs
 ' > /etc/xdg/weston/weston.ini
 
-# Deprioritize ipv6
+# Deprioritize IPv6 to address Steam client issues where it is hard-coded to use IPv4
+# https://github.com/ValveSoftware/steam-for-linux/issues/3372
 echo 'label  ::1/128       0
 label  ::/0          1
 label  2002::/16     2


### PR DESCRIPTION
The default configuration was previously overridden. This can lead to seemingly broken IPv6 network connections.