### PR TITLE
move files to package instead of generating them post install

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg
+++ b/kickstart/playtron-os_kickstart.cfg
@@ -37,9 +37,6 @@ xconfig --defaultdesktop GNOME --startxonboot
 # Disable the Fedora first-time setup agent. We will (eventually) provide our own.
 firstboot --disable
 
-# enable system services
-services --enabled=lightdm,create-swap,resize-root-file-system
-
 # Run post-installation shell commands.
 %post --logfile=/root/kickstart-post.log --erroronfail
 
@@ -49,80 +46,10 @@ set -x
 # Enable immediate exit on fail
 set -e
 
-# enable playserve user service - HACK: using /etc temporarily as a workaround, should use /usr
-mkdir -p /etc/systemd/user/graphical-session.target.wants
-ln -s /usr/lib/systemd/user/playserve.service /etc/systemd/user/graphical-session.target.wants/playserve.service
-
 # Create the "playtron" user manually.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1838859
-echo '%wheel ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/wheel
 useradd -G wheel playtron
 echo "playtron:playtron" | chpasswd
-
-# Automatically login the "playtron" user into gamescope.
-mkdir -p /etc/lightdm/lightdm.conf.d
-echo '
-# Basic configuration for seat. The session should be filled in into a
-# file under /etc/lightdm/lightdm.conf.d/
-[LightDM]
-run-directory=/run/lightdm
-logind-check-graphical=true
-[Seat:*]
-greeter-session=lightdm-autologin-greeter
-autologin-user=playtron
-' > /etc/lightdm/lightdm.conf
-
-echo '
-[Seat:*]
-autologin-session=gamescope-session-playtron
-' > /etc/lightdm/lightdm.conf.d/50-playtron-session-default.conf
-
-# Allow running OS upgrades without a password
-mkdir -p /etc/polkit-1/rules.d
-echo '
-polkit.addRule(function(action, subject) {
-    if (action.id == "org.projectatomic.rpmostree1.upgrade" && subject.isInGroup("wheel")) {
-        return polkit.Result.YES;
-    }
-});
-' > /etc/polkit-1/rules.d/50-one.playtron.rpmostree1.rules
-
-# Configure default dev session
-mkdir -p /etc/xdg/weston
-echo '
-[core]
-xwayland=true
-idle-time=0
-
-[launcher]
-icon=/usr/share/weston/icon_terminal.png
-path=/usr/bin/weston-terminal
-
-[launcher]
-icon=/usr/share/icons/hicolor/16x16/apps/firefox.png
-path=/usr/bin/firefox
-
-[launcher]
-icon=/usr/share/icons/hicolor/16x16/apps/steam.png
-path=/usr/bin/steam
-
-[launcher]
-icon=/usr/share/icons/Adwaita/16x16/mimetypes/application-x-executable.png
-path=/usr/bin/playtron-labs
-' > /etc/xdg/weston/weston.ini
-
-# Deprioritize IPv6 to address Steam client issues where it is hard-coded to use IPv4
-# https://github.com/ValveSoftware/steam-for-linux/issues/3372
-echo 'label  ::1/128       0
-label  ::/0          1
-label  2002::/16     2
-label ::/96          3
-label ::ffff:0:0/96  4
-precedence  ::1/128       50
-precedence  ::/0          40
-precedence  2002::/16     30
-precedence ::/96          20
-precedence ::ffff:0:0/96  100' > /etc/gai.conf
 
 # Fix permissions.
 chown -R -v 1000:1000 /var/home/playtron


### PR DESCRIPTION
 - Removing files being generated by the kickstart script (hacky and bad), instead we will package them.
 - Enabling services will be done by using systemd presets and rpm install hooks.
 
This way, all changes to these configuration files can be part of any future updates.