### PR TITLE
[kickstart] Enable deep S3 sleep by default

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg
+++ b/kickstart/playtron-os_kickstart.cfg
@@ -4,7 +4,7 @@
 ignoredisk --only-use=vda
 zerombr
 clearpart --all --initlabel --drives=vda
-bootloader --location=mbr --boot-drive=vda
+bootloader --location=mbr --boot-drive=vda --append="mem_sleep_default=deep"
 autopart --type btrfs
 
 # Setup the file system.


### PR DESCRIPTION
If the hardware does not support it, it will be silently ignored.