### PR TITLE
[kickstart] Add the user to the 'input' group

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg
+++ b/kickstart/playtron-os_kickstart.cfg
@@ -48,7 +48,9 @@ set -e
 
 # Create the "playtron" user manually.
 # https://bugzilla.redhat.com/show_bug.cgi?id=1838859
-useradd -G wheel playtron
+# Put the user in the "wheel" group for elevated privileges and "input" for Autotest to work.
+grep -E '^input:' /usr/lib/group | tee -a /etc/group
+useradd -G wheel,input playtron
 echo "playtron:playtron" | chpasswd
 
 # Fix permissions.


### PR DESCRIPTION
This allows Autotest to access and manage input devices.