### PR TITLE
Add InputPlumber to OS build

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -59,6 +59,8 @@ packages:
   - lightdm
   - lightdm-autologin-greeter
   - xwininfo
+  # Input Management
+  - inputplumber
   # for playview
   - webkit2gtk4.1
   # for Steam


### PR DESCRIPTION
This change adds the [InputPlumber](https://github.com/ShadowBlip/InputPlumber) package to PlaytronOS builds. This change will also require a service update to configure InputPlumber to start on system boot: https://github.com/playtron-os/playtron-os-files/pull/19