### PR TITLE
[rpm-ostree] Install 'evtest'

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -61,6 +61,7 @@ packages:
   - xwininfo
   # Input Management
   - inputplumber
+  - evtest
   # for playview
   - webkit2gtk4.1
   # for Steam


### PR DESCRIPTION
This change will add the `evtest` binary to PlaytronOS. This tool can be used to test and validate input events from input devices, and is valuable for debugging potential input issues on a variety of input devices.