### PR TITLE
[rpm-ostree] Use kernel-fsync

### DIFF
--- a/rpm-ostree/kernel-fsync.repo
+++ b/rpm-ostree/kernel-fsync.repo
@@ -1,0 +1,12 @@
+[kernel-fsync-x86_64]
+name=Copr repo for gaming owned by playtron
+#TODOF40 - When Fedora 40 stable is released and this Fedora Copr is updated,
+# use "fedora-$releasever-x86_64" instead.
+baseurl=https://download.copr.fedorainfracloud.org/results/sentry/kernel-fsync/fedora-39-x86_64/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/sentry/kernel-fsync/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/rpm-ostree/playtron-gaming-x86_64.repo
+++ b/rpm-ostree/playtron-gaming-x86_64.repo
@@ -8,3 +8,4 @@ gpgkey=https://download.copr.fedorainfracloud.org/results/playtron/gaming/pubkey
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
+exclude=kernel*

--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -95,6 +95,7 @@ repos:
   - fedora-40
   - fedora-40-updates
   - fedora-cisco-openh264
+  - kernel-fsync-x86_64
   - playtron-gaming-x86_64
   - playtron-gaming-i386
   - playtron-app-x86_64


### PR DESCRIPTION
for better hardware compatibility. We will be moving our patches and contributions over to this community kernel.