### PR TITLE
fix login and TLS issues

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -54,6 +54,7 @@ packages:
   ### Other packages.
   - steam
   # Playtron
+  - glib-networking
   - playserve
   - playview
   #- autotest


### PR DESCRIPTION
`glib-networking` was previously being pulled in by `playtron-labs` which was removed.