### PR TITLE
downgrade wireplumber

### DIFF
--- a/rpm-ostree/fedora-40-updates.repo
+++ b/rpm-ostree/fedora-40-updates.repo
@@ -6,4 +6,4 @@ baseurl=https://mirror.rackspace.com/fedora/updates/40/Everything/x86_64/
 enabled=0
 gpgcheck=1
 metadata_expire=1d
-exclude=kernel* ffmpeg-free mesa-va-drivers mesa-vdpau-drivers mesa-va-drivers.i686 mesa-vdpau-drivers.i686 libswscale-free
+exclude=kernel* ffmpeg-free mesa-va-drivers mesa-vdpau-drivers mesa-va-drivers.i686 mesa-vdpau-drivers.i686 libswscale-free mangohud wireplumber*

--- a/rpm-ostree/fedora-40.repo
+++ b/rpm-ostree/fedora-40.repo
@@ -5,4 +5,4 @@ baseurl=https://mirror.rackspace.com/fedora/development/40/Everything/x86_64/os/
 enabled=1
 gpgcheck=1
 metadata_expire=1d
-exclude=kernel* ffmpeg-free mesa-va-drivers mesa-vdpau-drivers mesa-va-drivers.i686 mesa-vdpau-drivers.i686 libswscale-free mangohud
+exclude=kernel* ffmpeg-free mesa-va-drivers mesa-vdpau-drivers mesa-va-drivers.i686 mesa-vdpau-drivers.i686 libswscale-free mangohud wireplumber*


### PR DESCRIPTION
- Successfully tested wireplumber and wireplumber-libs 0.4.17-1 on PlaytronOS 0.13.2.28
- Uploaded wireplumber and wireplumber-libs 0.4.17-1 to the playtron gaming repo on AWS
- Excluded wireplumber packages from the main Fedora repositories
- Also added an unrelated missing exclusion for mangohud to the Fedora updates repository