### PR TITLE
[rpm-ostree] Add 'valve-firmware' package

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -27,6 +27,7 @@ packages:
   - gdisk
   - playtron-os-files
   - udev-media-automount
+  - valve-firmware
   ## Mesa is already pulled in as part of the Fedora Silverblue configuration.
   #- mesa
   # winetricks helps manage Wine prefixes.


### PR DESCRIPTION
for initial Steam Deck OLED support.