### PR TITLE
PTCORE-1393 fix dev session

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -72,7 +72,7 @@ packages:
   # for Steam
   - lsb_release
   # for dev/debug mode session
-  - weston
+  - weston-session
   # Xorg packages for Fedora.
   ## These are no longer included in fedora-common-ostree-pkgs.yaml as of Fedora 39.
   - xorg-x11-drv-amdgpu


### PR DESCRIPTION
The weston session was split from the `weston` package in Fedora 40 into the `weston-session` package.

`weston-session` depends on `weston`.