### PR TITLE
[rpm-ostree][kickstart] Use Fedora 40 stable

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg
+++ b/kickstart/playtron-os_kickstart.cfg
@@ -13,8 +13,7 @@ ostreesetup --osname playtron-os --remote playtron-os --url "https://playtron-de
 # Reboot and start the installer.
 reboot
 text
-#TODOF40 - When Fedora 40 stable is released, replace "development" with "releases" in the path.
-url --url="https://mirror.rackspace.com/fedora/development/40/Everything/x86_64/os/"
+url --url="https://mirror.rackspace.com/fedora/releases/40/Everything/x86_64/os/"
 
 # U.S.A. keyboard and langauge settings.
 keyboard --vckeymap=us --xlayouts='us'

--- a/kickstart/virt-install.sh
+++ b/kickstart/virt-install.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-#TODOF40 - When Fedora 40 stable is released, replace "development" with "releases" in the path.
 sudo virt-install \
   --connect qemu:///system \
   --virt-type kvm --graphics spice --video vga\
@@ -9,7 +8,7 @@ sudo virt-install \
   --boot uefi \
   --vcpus 4 --ram 16384 \
   --disk=/var/lib/libvirt/images/playtron-os.img,bus=virtio,format=raw,size=8 \
-  --location=https://mirror.rackspace.com/fedora/development/40/Everything/x86_64/os/ \
+  --location=https://mirror.rackspace.com/fedora/releases/40/Everything/x86_64/os/ \
   --initrd-inject ./playtron-os_kickstart.cfg \
   --extra-args="inst.ks=file:/playtron-os_kickstart.cfg net.ifnames=0 biosdevname=0" \
   --noreboot

--- a/rpm-ostree/fedora-40-updates.repo
+++ b/rpm-ostree/fedora-40-updates.repo
@@ -1,9 +1,7 @@
 [fedora-40-updates]
 name=Fedora 40 $basearch Updates
 baseurl=https://mirror.rackspace.com/fedora/updates/40/Everything/x86_64/
-# The Fedora 40 updates repository does not exist yet.
-#TODOF40 - When Fedora 40 stable is released, enable this repository.
-enabled=0
+enabled=1
 gpgcheck=1
 metadata_expire=1d
 exclude=kernel* ffmpeg-free mesa-va-drivers mesa-vdpau-drivers mesa-va-drivers.i686 mesa-vdpau-drivers.i686 libswscale-free mangohud wireplumber*

--- a/rpm-ostree/fedora-40.repo
+++ b/rpm-ostree/fedora-40.repo
@@ -1,7 +1,6 @@
 [fedora-40]
 name=Fedora 40 $basearch
-#TODOF40 - When Fedora 40 stable is released, replace "development" with "releases" in the path.
-baseurl=https://mirror.rackspace.com/fedora/development/40/Everything/x86_64/os/
+baseurl=https://mirror.rackspace.com/fedora/releases/40/Everything/x86_64/os/
 enabled=1
 gpgcheck=1
 metadata_expire=1d

--- a/rpm-ostree/kernel-fsync.repo
+++ b/rpm-ostree/kernel-fsync.repo
@@ -1,8 +1,6 @@
 [kernel-fsync-x86_64]
 name=Copr repo for gaming owned by playtron
-#TODOF40 - When Fedora 40 stable is released and this Fedora Copr is updated,
-# use "fedora-$releasever-x86_64" instead.
-baseurl=https://download.copr.fedorainfracloud.org/results/sentry/kernel-fsync/fedora-39-x86_64/
+baseurl=https://download.copr.fedorainfracloud.org/results/sentry/kernel-fsync/fedora-40-x86_64/
 type=rpm-md
 skip_if_unavailable=True
 gpgcheck=1


### PR DESCRIPTION
Currently untested but this should fix our recent build issues since the Fedora 40 beta repositories have been removed.