### PR TITLE
fix playtron logo on boot

### DIFF
--- a/kickstart/playtron-os_kickstart.cfg.template
+++ b/kickstart/playtron-os_kickstart.cfg.template
@@ -83,13 +83,6 @@ chown -R -v 1000:1000 /var/home/playtron
 crudini --ini-options=nospace --set /etc/default/grub "" GRUB_TIMEOUT 0
 crudini --ini-options=nospace --set /etc/default/grub "" GRUB_TIMEOUT_STYLE hidden
 
-# Force the initramfs to be rebuilt to use the new 'dracut-config-generic' configuration.
-# It will build all kernel modules into the initramfs to make it more portable.
-# By default, Fedora only creates an initramfs with the kernel modules for the current system.
-# When using a rpm-ostree compose without a unified core, /var/tmp does not exist yet but /tmp does.
-for i in $(ls -1 /lib/modules); do mkdir -p "/boot/efi/Default/${i}"; done
-dracut --tmpdir /tmp --regenerate-all --force
-
 # Rebuild the GRUB configuration file.
 # This will load hidden boot menu settings and the new EFI boot entries.
 grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg

--- a/rpm-ostree/Containerfile
+++ b/rpm-ostree/Containerfile
@@ -52,3 +52,8 @@ RUN wget https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/
 COPY rootfs/etc/bluetooth/main.conf /etc/bluetooth/
 COPY rootfs/usr/lib/os-release-playtron /usr/lib/
 COPY rootfs/usr/share/plymouth/themes/spinner/watermark.png /usr/share/plymouth/themes/spinner/
+
+# Finalize initramfs
+RUN KERNEL=$(echo /lib/modules/*/initramfs.img | cut -d'/' -f4) \
+  && dracut --reproducible -v --add 'ostree' -f --no-hostonly --kver ${KERNEL} /lib/modules/${KERNEL}/initramfs.img \
+  && ostree container commit


### PR DESCRIPTION
Testing:
 - updated to a fixed container and observed Playtron logo on boot
 - installed a fresh fixed disk image and observed Playtron logo on boot