### PR TITLE
ignore legendary from Fedora repos

### DIFF
--- a/rpm-ostree/fedora-40-updates.repo
+++ b/rpm-ostree/fedora-40-updates.repo
@@ -4,4 +4,4 @@ baseurl=https://mirror.rackspace.com/fedora/updates/40/Everything/x86_64/
 enabled=1
 gpgcheck=1
 metadata_expire=1d
-exclude=kernel* ffmpeg-free libswscale-free mangohud mesa* wireplumber*
+exclude=kernel* ffmpeg-free libswscale-free mangohud mesa* wireplumber* legendary

--- a/rpm-ostree/fedora-40.repo
+++ b/rpm-ostree/fedora-40.repo
@@ -4,4 +4,4 @@ baseurl=https://mirror.rackspace.com/fedora/releases/40/Everything/x86_64/os/
 enabled=1
 gpgcheck=1
 metadata_expire=1d
-exclude=kernel* ffmpeg-free libswscale-free mangohud mesa* wireplumber*
+exclude=kernel* ffmpeg-free libswscale-free mangohud mesa* wireplumber* legendary


### PR DESCRIPTION
Force the build to use the legendary from the PlaytronOS copr repo.