### PR TITLE
[rpm-ostree] Remove manual audio extraction

### DIFF
--- a/rpm-ostree/Containerfile
+++ b/rpm-ostree/Containerfile
@@ -38,16 +38,6 @@ RUN rpm-ostree install \
   steam.i686 \
   && ostree container commit
 
-
-# Add firmware and configuration files needed for Steam Deck OLED audio support.
-RUN wget https://steamdeck-packages.steamos.cloud/archlinux-mirror/jupiter-main/os/x86_64/steamdeck-dsp-0.49-1-any.pkg.tar.zst -O /tmp/steamdeck-dsp.tar.zst \
-  # There are tar extraction errors about file system attributes that can be safely ignored.
-  && tar -xvf /tmp/steamdeck-dsp.tar.zst -C / || true \
-  # Verify that the extraction actually worked.
-  && ls /usr/lib/firmware/amd/sof/sof-vangogh-code.bin \
-  && rm -f /tmp/steamdeck-dsp.tar.zst \
-  && ostree container commit
-
 # Copy/override files
 COPY rootfs/etc/hostname /etc/
 COPY rootfs/etc/bluetooth/main.conf /etc/bluetooth/


### PR DESCRIPTION
for Steam Deck OLED support. It is now handled via the 'valve-firmware' package instead.