### PR TITLE
PTCORE-1910 add udisks2 package to fix external storage not working

### DIFF
--- a/rpm-ostree/playtron-os.yaml
+++ b/rpm-ostree/playtron-os.yaml
@@ -59,8 +59,7 @@ packages:
   - glib-networking
   - playserve
   - playview
-  #- autotest
-  #- playtron-labs
+  - udisks2
   - zstd
   - lightdm
   - lightdm-autologin-greeter


### PR DESCRIPTION
Looks like udisks2 got lost somewhere. Perhaps during the chaotic transition to container builds.

Tested by manually installing udisks2 on PlaytronOS 0.17.4.59 and confirmed external storage works.