### PR TITLE
[containerfiles] Install Flatpak again

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -34,6 +34,7 @@ RUN ${CMD_INSTALL} \
   distrobox \
   dracut-config-generic \
   evtest \
+  flatpak \
   gamescope-session-playtron \
   glibc-langpack-en \
   gstreamer1-plugins-good \
@@ -95,6 +96,10 @@ RUN ${CMD_INSTALL} \
   xorg-x11-server-Xvfb \
   xwininfo \
   zenity
+
+# Configure the FlatHub remote.
+RUN flatpak remote-delete fedora && \
+  flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
 # Install Nvidia driver
 RUN ${CMD_INSTALL} \


### PR DESCRIPTION
this used to be included in older rpm-ostree builds. Also use the full Flathub remote repository which has more packages that are also more up-to-date.