### PR TITLE
Add various monitoring tools

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -27,6 +27,7 @@ RUN ${CMD_INSTALL} \
   binutils \
   bluez \
   brcmfmac-firmware \
+  btop \
   cabextract \
   cirrus-audio-firmware \
   crudini \
@@ -38,8 +39,10 @@ RUN ${CMD_INSTALL} \
   gamescope-session-playtron \
   glibc-langpack-en \
   gstreamer1-plugins-good \
+  htop \
   inputplumber \
   intel-audio-firmware \
+  iotop \
   iwlegacy-firmware \
   iwlwifi-dvm-firmware \
   iwlwifi-mvm-firmware \
@@ -70,6 +73,7 @@ RUN ${CMD_INSTALL} \
   plymouth \
   plymouth-theme-spinner \
   powerstation \
+  powertop \
   realtek-firmware \
   sddm \
   steam.i686 \


### PR DESCRIPTION
This adds some monitoring tools to help with optimizing battery usage.

- btop: All in one monitoring (CPU, GPU, RAM, thermals, power, io, network, processes)
- htop: Process monitor
- iotop: Monitor disk activity
- powertop: Monitor power usage and battery