### PR TITLE
Fix plymouth when building disk images with bootc-image-builder

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -127,7 +127,7 @@ tasks:
       - rm -rf output
       - mkdir output
       - podman pull ${REGISTRY}/${PROJECT}/${IMAGE}:${TAG}
-      - podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v ./config.toml:/config.toml:ro -v ./output:/output -v /var/lib/containers/storage:/var/lib/containers/storage registry.playtron.one/tools/bootc-image-builder:latest --type raw --rootfs btrfs ${REGISTRY}/${PROJECT}/${IMAGE}:${TAG}
+      - podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v ./config.toml:/config.toml:ro -v ./output:/output -v /var/lib/containers/storage:/var/lib/containers/storage ghcr.io/playtron-os/bootc-image-builder:latest --type raw --rootfs btrfs ${REGISTRY}/${PROJECT}/${IMAGE}:${TAG}
 
   disk-image:bootc:local:
     desc: Build the OS image from a local container using bootc image builder.
@@ -139,7 +139,7 @@ tasks:
     cmds:
       - rm -rf output
       - mkdir output
-      - podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v ./config.toml:/config.toml:ro -v ./output:/output -v /var/lib/containers/storage:/var/lib/containers/storage registry.playtron.one/tools/bootc-image-builder:latest --type raw --rootfs btrfs localhost/${IMAGE}:${TAG}
+      - podman run --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t -v ./config.toml:/config.toml:ro -v ./output:/output -v /var/lib/containers/storage:/var/lib/containers/storage ghcr.io/playtron-os/bootc-image-builder:latest --type raw --rootfs btrfs localhost/${IMAGE}:${TAG}
 
   repo:update:
     desc: "Update the package repository"


### PR DESCRIPTION
 - use custom build of bootc-image-builder to fix plymouth
 - add bootc disk image build task from local container

Also:
 - forked bootc-image-builder and applied a fix for plymouth (https://github.com/playtron-os/bootc-image-builder)
 - built the custom bootc-image-builder and pushed to a new internal tools container repository