### PR TITLE
[containerfiles] Use 'bootc container lint'

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -23,5 +23,14 @@ RUN dnf5 -y upgrade \
   valve-firmware-20231113.1-5.fc41 \
   SteamBus-1.20.0-1.fc41
 
+# Clear cache.
+RUN dnf5 clean all && \
+  rm -r -f \
+    /boot/.vmlinuz*.hmac \
+    /var/cache/*
+
 # View final packages.
 RUN rpm -qa | sort
+
+# View how well we adhere to bootc best practices.
+RUN bootc container lint

--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -102,9 +102,6 @@ RUN ${CMD_INSTALL} \
   xwininfo \
   zenity
 
-# Configure the FlatHub remote.
-RUN flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-
 # Install Nvidia driver
 RUN ${CMD_INSTALL} \
   --setopt=disable_excludes=* \
@@ -166,8 +163,14 @@ RUN KERNEL=$(echo /lib/modules/*/vmlinuz | cut -d'/' -f4) \
 RUN rm -rf /var/run
 RUN ln -s /run /var/run
 
-# Clear /var/cache
-RUN rm -rf /var/cache/*
+# Clear cache.
+RUN dnf5 clean all && \
+  rm -r -f \
+    /boot/.vmlinuz*.hmac \
+    /var/cache/*
 
 # View final packages
 RUN rpm -qa | sort --ignore-case
+
+# View how well we adhere to bootc best practices.
+RUN bootc container lint


### PR DESCRIPTION
to show possible issues and to make sure we are following best standards.

Also do more clean up and avoid setting a Flathub remote to avoid some warnings. There is a hint in the README.md already for how to enable Flathub.