### PR TITLE
workaround for inputplumber service being disabled

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -28,6 +28,9 @@ RUN dnf5 clean all && \
     /boot/.vmlinuz*.hmac \
     /var/cache/*
 
+# Work around for inputplumber service not being enabled
+RUN cd /etc/systemd/system/multi-user.target.wants && ln -s /usr/lib/systemd/system/inputplumber.service .
+
 # View final packages.
 RUN rpm -qa | sort
 


### PR DESCRIPTION
I compared older OS containers to newer ones and noticed that the inputplumber service was not linked for some reason. Unsure why, as nothing relevant to that process has changed.

This adds the link back, working around the issue, although not addressing whatever might be the root cause.