### PR TITLE
fix build: remove missing package

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -110,7 +110,6 @@ RUN ${CMD_INSTALL} \
 
 RUN ${CMD_INSTALL} \
   akmod-nvidia \
-  nvenc \
   nvidia-driver \
   nvidia-driver-NvFBCOpenGL \
   nvidia-driver-libs.i686


### PR DESCRIPTION
Not sure why, but `nvenc` is gone. I poked around in a bunch of repos, but could not even find it existing historically. :shrug: 

Maybe it has been merged into another package?