### PR TITLE
Print available os version when an update is available

### DIFF
--- a/rootfs/usr/bin/playtronos-update
+++ b/rootfs/usr/bin/playtronos-update
@@ -175,10 +175,27 @@ update() {
 	esac
 }
 
+print_available_version() {
+	VERSION_MATCH="[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+"
+	if cat /etc/playtron-os.conf | grep "TAG=" > /dev/null; then
+		# internal build case: grab the explicitly selected version
+		version=$(cat /etc/playtron-os.conf | grep "TAG=" | cut -d"=" -f2)
+
+		if echo "${version}" | grep -E "${VERSION_MATCH}" > /dev/null; then
+			# exclude non-version number tags
+			echo "Available version: ${version}"
+		fi
+	else
+		# public build case: find the highest number version tag in the container registry
+		echo "Available version: "$(skopeo list-tags docker://ghcr.io/playtron-os/playtron-os | grep -E "${VERSION_MATCH}" | sort -n -r | head -1 | tr -d '[:blank:]",')
+	fi
+}
+
 check() {
 	case $(__rebase_status) in
 		"needed")
 			echo "New update available (rebase)"
+			print_available_version
 			exit 0
 		;;
 		"completed")
@@ -187,6 +204,11 @@ check() {
 		;;
 		"none")
 			rpm-ostree upgrade --check
+			result=$?
+			if [ "$result" == "0" ]; then
+				print_available_version
+			fi
+			exit $result
 		;;
 		*)
 			echo "ERROR: Unknown rebase status"

--- a/rootfs/usr/bin/playtronos-update
+++ b/rootfs/usr/bin/playtronos-update
@@ -187,7 +187,8 @@ print_available_version() {
 		fi
 	else
 		# public build case: find the highest number version tag in the container registry
-		echo "Available version: "$(skopeo list-tags docker://ghcr.io/playtron-os/playtron-os | grep -E "${VERSION_MATCH}" | sort -n -r | head -1 | tr -d '[:blank:]",')
+		version=$(skopeo list-tags docker://ghcr.io/playtron-os/playtron-os | grep -E "${VERSION_MATCH}" | sort -n -r | head -1 | tr -d '[:blank:]",')
+		echo "Available version: ${version}"
 	fi
 }
 


### PR DESCRIPTION
 - For internal builds, can only grab the version if it was explicitly selected in the OS build menu
 - In all other cases, we grab the list of tags from the github container registry and sort numerically to find the latest release

The version number will not be accurate if a user manually rebases the system to something other than `ghcr.io/playtron-os/playtron-os:latest`.