### PR TITLE
fix(ROG Ally/Ally X): use devices from updated driver

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
+++ b/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml
@@ -46,6 +46,21 @@ source_devices:
       vendor_id: 0b05
       product_id: 1abe
       handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: mouse
+    evdev:
+      name: ROG Ally Mouse
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: keyboard
+    unique: false
+    evdev:
+      name: ROG Ally Keyboard
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
   - group: imu
     iio:
       name: bmi323-imu
@@ -53,6 +68,10 @@ source_devices:
         x: [1, 0, 0]
         y: [0, -1, 0]
         z: [0, 0, -1]
+  - group: led
+    udev:
+      sys_name: ally:rgb:joystick_rings
+      subsystem: leds
   - group: touchscreen
     udev:
       properties:

--- a/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
@@ -45,6 +45,27 @@ source_devices:
       vendor_id: 0b05
       product_id: 1b4c
       handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: mouse
+    evdev:
+      name: "ROG Ally Mouse"
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: keyboard
+    evdev:
+      name: "ROG Ally Keyboard"
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: gamepad 
+    evdev:
+      name: ROG Ally X Gamepad
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
   - group: imu
     iio:
       name: bmi323-imu


### PR DESCRIPTION
This change updates our device overrides for the Ally/Ally X to grab devices produced by the new `asus_ally_hid` driver:
https://github.com/ShadowBlip/InputPlumber/commit/ab227db7c6b4f0a329b93bd67cbf2172e388e8d0