### PR TITLE
Include glibc-locale-source to build locales from pressure vessel

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -52,6 +52,7 @@ RUN ${CMD_INSTALL} \
   fwupd \
   gamescope-session-playtron \
   glibc-langpack-en \
+  glibc-locale-source \
   google-noto-sans-mono-cjk-vf-fonts \
   gstreamer1-plugins-good \
   htop \


### PR DESCRIPTION
Without this package, pressure vessel will complain about not finding the charmaps to build different locales and fail doing so. 


This package populates charmaps in /usr/share/i18n/charmaps/