### PR TITLE
remove custom os update location config file during factory reset

### DIFF
--- a/rootfs/usr/bin/playtron-factory-reset
+++ b/rootfs/usr/bin/playtron-factory-reset
@@ -74,7 +74,7 @@ reset_etc ssh
 reset_etc xdg
 rsync -aHX /usr/etc/gai.conf /etc/gai.conf
 rsync -aHX /usr/etc/sddm.conf /etc/sddm.conf
-rm /etc/playtron-os.conf
+rm -f /etc/playtron-os.conf
 
 # reset playtron password
 echo 'playtron:playtron' | chpasswd

--- a/rootfs/usr/bin/playtron-factory-reset
+++ b/rootfs/usr/bin/playtron-factory-reset
@@ -74,6 +74,7 @@ reset_etc ssh
 reset_etc xdg
 rsync -aHX /usr/etc/gai.conf /etc/gai.conf
 rsync -aHX /usr/etc/sddm.conf /etc/sddm.conf
+rm /etc/playtron-os.conf
 
 # reset playtron password
 echo 'playtron:playtron' | chpasswd


### PR DESCRIPTION
Discovered this when speaking with a tester that after a factory reset continued to see OS updates as being available in the UI.