### PR TITLE
fix(ROG Ally X): add LEDs to device config

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml
@@ -73,6 +73,10 @@ source_devices:
         x: [1, 0, 0]
         y: [0, -1, 0]
         z: [0, 0, -1]
+  - group: led
+    udev:
+      sys_name: ally:rgb:joystick_rings
+      subsystem: leds
   - group: touchscreen
     udev:
       properties:


### PR DESCRIPTION
This change adds the LED joystick rings to the device config based on the upstream config.