### PR TITLE
Add download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Turn your PC into a game console. Playtron GameOS has native integration with Ep
 
 Read more about Playtron on [our official website](https://www.playtron.one/).
 
+[Download Playtron GameOS here](https://www.playtron.one/game-os#download-playtron-os).
+
 ## Minimum Hardware Requirements
 
 - CPU

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Table of Contents:
 
 ## Introduction
 
-Turn your PC into a game console. GameOS has native integration with Epic Games Store, GOG.com, and Steam. Your library of games is accessible via a simple gamer-focused interface.
+Turn your PC into a game console. Playtron GameOS has native integration with Epic Games Store, GOG.com, and Steam. Your library of games is accessible via a simple gamer-focused interface.
 
-Read more about Playtron GameOS on our official [website](https://www.playtron.one/).
+Read more about Playtron on [our official website](https://www.playtron.one/).
 
 ## Minimum Hardware Requirements
 
@@ -31,7 +31,7 @@ Most games are expected to work. For problematic games, you can help our communi
 
 ## Sideloading Games
 
-Local games can be copied over to GameOS and integrated using the [local](https://github.com/playtron-os/plugin-local) plugin. It is installed by default as of GameOS Beta 1.
+Local games can be copied over to Playtron GameOS and integrated using the [local](https://github.com/playtron-os/plugin-local) plugin. It is installed by default as of Beta 1.
 
 ## Build
 
@@ -175,7 +175,7 @@ $ sudo podman build --tag desktop:latest .
 $ sudo bootc switch --transport containers-storage localhost/desktop:latest
 ```
 
-The Software Update feature in Settings will no longer work with a custom container from the last example. All future updates must be done with locally built containers. Otherwise, switch back to an unmodified installation of GameOS.
+The Software Update feature in Settings will no longer work with a custom container from the last example. All future updates must be done with locally built containers. Otherwise, switch back to an unmodified installation of Playtron GameOS.
 
 ```
 $ sudo bootc switch ghcr.io/playtron-os/playtron-os:latest

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Most games are expected to work. For problematic games, you can help our communi
 
 ## Sideloading Games
 
-Local games can be copied over to Playtron GameOS and integrated using the [local](https://github.com/playtron-os/plugin-local) plugin. It is installed by default as of Beta 1.
+Local games can be copied over to Playtron GameOS and integrated using the [local](https://github.com/playtron-os/plugin-local) plugin.
 
 ## Build
 


### PR DESCRIPTION
Users keep asking where to download Playtron GameOS. This adds a download link to the top of the GitHub project to make it easier for people to find.