### PR TITLE
install mode implementation and build support

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -2,3 +2,17 @@
 name = "playtron"
 password = "playtron"
 groups = ["wheel"]
+
+[[customizations.directories]]
+path = "/etc/environment.d"
+user = "root"
+group = "root"
+
+# switch Grid to install mode
+[[customizations.files]]
+path = "/etc/environment.d/playtron-installer.conf"
+data = "GRID_INSTALL_MODE=1"
+
+# disable resize-root-file-system service
+[[customizations.files]]
+path = "/etc/systemd/system/resize-root-file-system.service"

--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -92,6 +92,7 @@ RUN ${CMD_INSTALL} \
   plymouth-theme-spinner \
   powerstation \
   powertop \
+  pv \
   python3-pygame \
   python3-dbus \
   python3-gobject \
@@ -319,6 +320,10 @@ COPY rootfs/usr/share/polkit-1/rules.d/50-one.playtron.rpmostree1.rules			/usr/s
 
 # Custom playtron weston session file
 COPY rootfs/usr/share/wayland-sessions/playtron-weston.desktop				/usr/share/wayland-sessions/
+
+# Install mode files
+COPY rootfs/usr/libexec/playtron/os-install						/usr/libexec/playtron/
+COPY rootfs/usr/share/polkit-1/rules.d/50-one.playtron.os-install.rules			/usr/share/polkit-1/rules.d/
 
 # Configure SELinux.
 RUN mkdir -p /usr/share/selinux/playtron-modules

--- a/rootfs/usr/libexec/playtron/os-install
+++ b/rootfs/usr/libexec/playtron/os-install
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+if [ $EUID -ne 0 ]; then
+	echo "$(basename "$0") must be run as root"
+	exit 1
+fi
+
+
+function disable_install_mode {
+	rm -rf root/ostree/deploy/default/deploy/*/etc/environment.d
+	rm -f root/ostree/deploy/default/deploy/*/etc/systemd/system/resize-root-file-system.service
+}
+
+OS_NAME="Playtron GameOS"
+RAW_DISK_SIZE=20G
+SOURCE_DISK=$1
+TARGET_DISK=$2
+
+umount ${TARGET_DISK}*
+
+pv ${SOURCE_DISK} --output ${TARGET_DISK} --size ${RAW_DISK_SIZE} --stop-at-size --numeric 2>&1
+
+if [ "$?" != "0" ]; then
+    exit 1
+fi
+
+# ensure progress is at 100%
+echo "100"
+
+efibootmgr --delete-bootnum --label "${OS_NAME}" || true
+efibootmgr --create --disk ${TARGET_DISK} --part 2 --loader \\EFI\\fedora\\shim.efi --label "${OS_NAME}"
+
+mkdir -p /tmp/playtron-install-target
+mount  ${TARGET_DISK}*4 /tmp/playtron-install-target
+pushd  /tmp/playtron-install-target
+disable_install_mode
+popd
+
+sync
+
+umount ${TARGET_DISK}*4

--- a/rootfs/usr/share/polkit-1/rules.d/50-one.playtron.os-install.rules
+++ b/rootfs/usr/share/polkit-1/rules.d/50-one.playtron.os-install.rules
@@ -1,0 +1,5 @@
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" && subject.isInGroup("wheel") && action.lookup("program") == "/usr/libexec/playtron/os-install") {
+        return polkit.Result.YES;
+    }
+});


### PR DESCRIPTION
- modifies the bootc image build configuration to create a disk image that runs Grid and the system in "install mode"
- add the "os-install" script which is called by Grid to actually perform the installation
- add polkit file to allow Grid to run the install script as root
- add `pv` package which the install script uses to perform the disk copy and output progress for the UI