### PR TITLE
OS-405 Fix os update script progress swallowing errors

### DIFF
--- a/rootfs/usr/bin/playtronos-update
+++ b/rootfs/usr/bin/playtronos-update
@@ -146,6 +146,9 @@ function __report_progress {
 			done_parts=$(echo "$done_parts + 1" | bc)
 
 	                echo "{ \"done_mb\": $(echo $done_mb | awk '{printf "%d", $0}'), \"total_mb\": $(echo $total_mb | awk '{printf "%d", $0}'), \"done_parts\": ${done_parts}, \"total_parts\": ${total_parts} }"
+		elif [[ $line =~ "error:" ]]; then
+			echo $line
+			exit 1
 	        fi
 	done
 }


### PR DESCRIPTION
### Problem
Sometimes OS updates would appear to complete immediately and successfully, but were actually failing.

### Cause
The OS update script has functionality to convert progress from the underlying tooling into something easy to process for the calling application, however, it did not handle the case of errors and was swallowing/ignoring them.

### Solution
Detect errors, print them, and exit with an error code.

### Testing
I tested the following:
 - I ran the script from the command line where authentication is not performed to force an error and verified that an error is printed and a non-zero exit code is returned
 - I added a hard coded error and tested from the UI, to ensure the UI was displaying an error message
 - I performed a successful system update to ensure the non-error case still worked as expected