### PR TITLE
feat(systemd): use system service for Playserve

### DIFF
--- a/rootfs/usr/bin/playtron-factory-reset
+++ b/rootfs/usr/bin/playtron-factory-reset
@@ -25,7 +25,7 @@ fi
 echo "Shutting down services..."
 
 # make sure playserve is not running so that it does not write any files while we are performing the factory reset
-systemctl --user --machine=playtron@ stop playserve
+systemctl stop playserve
 
 if [ -n "$PRESERVE_USER_FILES" ]; then
 	echo "Performing partial factory reset..."

--- a/rootfs/usr/bin/playtronos-systemreport
+++ b/rootfs/usr/bin/playtronos-systemreport
@@ -146,7 +146,7 @@ if [[ " ${reports[*]} " =~ "services" ]]; then
   journalctl -b 0 >"${REPORT_DIR}/journal.log"
   journalctl -b 0 -u inputplumber >"${REPORT_DIR}/inputplumber.log"
   journalctl -b 0 -u powerstation >"${REPORT_DIR}/powerstation.log"
-  sudo -u "${TARGET_USER}" journalctl --user -u playserve -b >"${REPORT_DIR}/playserve.log"
+  journalctl -u playserve -b >"${REPORT_DIR}/playserve.log"
   sudo -u "${TARGET_USER}" journalctl --user -u gamescope-dbus -b >"${REPORT_DIR}/gamescope-dbus.log"
   sudo -u "${TARGET_USER}" journalctl --user -u gamescope-session-plus@playtron -b >"${REPORT_DIR}/gamescope-session.log"
 fi

--- a/rootfs/usr/bin/playtronos-update
+++ b/rootfs/usr/bin/playtronos-update
@@ -159,7 +159,7 @@ update() {
 			rpm-ostree rebase $BASE 2>&1 | __report_progress
 		;;
 		"completed")
-			return
+			true
 		;;
 		"none")
 			rpm-ostree upgrade 2>&1 | __report_progress
@@ -169,6 +169,10 @@ update() {
 			exit 1
 		;;
 	esac
+	# In newer versions of Playtron GameOS, the "tss" group membership is now handled by a system-level user service for Playserve.
+	if groupmems --list --group tss | grep playtron; then
+		gpasswd --delete playtron tss
+	fi
 }
 
 print_available_version() {

--- a/rootfs/usr/lib/systemd/system-preset/50-playtron.preset
+++ b/rootfs/usr/lib/systemd/system-preset/50-playtron.preset
@@ -2,6 +2,7 @@ enable auditd.service
 enable clatd-ipv6-check.service
 enable inputplumber.service
 enable NetworkManager-wait-online.service
+enable playserve.service
 enable resize-root-file-system.service
 enable restorecon-bootc.service
 enable sddm.service

--- a/rootfs/usr/lib/systemd/user-preset/50-playtron.preset
+++ b/rootfs/usr/lib/systemd/user-preset/50-playtron.preset
@@ -1,3 +1,2 @@
 enable pipewire-rnnoise-switch.service
-enable playserve.service
 enable gamescope-dbus.service


### PR DESCRIPTION
to provide an extra layer of security by restricting the 'tss' group.