### PR TITLE
ASUS ROG Ally X fix

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -6,12 +6,12 @@ COPY rootfs/usr/lib/os-release-playtron /usr/lib/
 # Upgrade kernel.
 RUN dnf remove -y kmod-nvidia* && \
   rpm-ostree override replace \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-6.15.8-201.nobara.fc41.x86_64.rpm \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-core-6.15.8-201.nobara.fc41.x86_64.rpm \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-devel-6.15.8-201.nobara.fc41.x86_64.rpm \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-devel-matched-6.15.8-201.nobara.fc41.x86_64.rpm \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-headers-6.15.8-201.nobara.fc41.x86_64.rpm \
-  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09382320-kernel/kernel-modules-6.15.8-201.nobara.fc41.x86_64.rpm
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-6.15.8-200.nobara.fc42.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-core-6.15.8-200.nobara.fc42.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-devel-6.15.8-200.nobara.fc42.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-devel-matched-6.15.8-200.nobara.fc42.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-headers-6.15.8-200.nobara.fc42.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/09319183-kernel/kernel-modules-6.15.8-200.nobara.fc42.x86_64.rpm
 # Rebuild NVIDIA drivers.
 RUN cp -r /etc/pam.d /etc/pam.d.bak; sed -i -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/*; \
   mkdir -p /run/akmods; \

--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -180,6 +180,7 @@ COPY rootfs/etc/yum.repos.d/inputplumber-x86_64.repo					/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/negativo17-fedora-nvidia.repo				/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/nobara-41-i386.repo						/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/nobara-41-x86_64.repo					/etc/yum.repos.d/
+COPY rootfs/etc/yum.repos.d/nobara-42-x86_64.repo					/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/playtron-app-x86_64.repo					/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/playtron-gaming-i386.repo					/etc/yum.repos.d/
 COPY rootfs/etc/yum.repos.d/playtron-gaming-x86_64.repo					/etc/yum.repos.d/

--- a/rootfs/etc/yum.repos.d/nobara-42-x86_64.repo
+++ b/rootfs/etc/yum.repos.d/nobara-42-x86_64.repo
@@ -1,0 +1,11 @@
+[nobara-42-x86_64]
+name=Copr repo for Nobara 42
+baseurl=https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/fedora-42-x86_64/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/gloriouseggroll/nobara-42/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1
+includepkgs=kernel*

--- a/rootfs/etc/yum.repos.d/playtron-gaming-x86_64.repo
+++ b/rootfs/etc/yum.repos.d/playtron-gaming-x86_64.repo
@@ -8,3 +8,4 @@ gpgkey=https://download.copr.fedorainfracloud.org/results/playtron/gaming/pubkey
 repo_gpgcheck=0
 enabled=1
 enabled_metadata=1
+exclude=kernel*


### PR DESCRIPTION
It has all of the patches we care about including ASUS ROG Ally X, support, SELinux support, and the Btrfs log corruption fix. All of these patches actually get pulled in from CachyOS.