### PR TITLE
kernel update only

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -1,25 +1,27 @@
-FROM registry.playtron.one/internal/playtronos:1.0.0.13
+FROM registry.playtron.one/internal/playtronos:1.0.0.30
 
 # Set OS version
 COPY rootfs/usr/lib/os-release-playtron /usr/lib/
 
-# https://github.com/playtron-os/rpm-specs-gaming
-RUN dnf5 -y upgrade \
-  gamescope-dbus-1.10.4-1 \
-  gamescope-session-0.1.0+306-1.fc41 \
-  gamescope-session-playtron-0.3.3-1.fc41 \
-  grid-1.8.3-1.fc40 \
-  inputplumber-0.60.7-0.fc41 \
-  legendary-0.20.37-1.playtron \
-  libpact-0.3.0-1 \
-  libplaytron-0.4.0-1 \
-  powerstation-0.6.1-1 \
-  playserve-1.5.2-1 \
-  playtron-plugin-local-1.3.0-1 \
-  reaper-0.1.0-2.fc41 \
-  tzupdate-3.1.0-1.fc41 \
-  udev-media-automount-0.1.0+71-1.fc41 \
-  SteamBus-1.25.2-1.fc41
+# Upgrade kernel.
+RUN dnf remove -y kmod-nvidia* && \
+  rpm-ostree override replace \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-6.15.8-203.nobara.fc41.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-core-6.15.8-203.nobara.fc41.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-devel-6.15.8-203.nobara.fc41.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-devel-matched-6.15.8-203.nobara.fc41.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-headers-6.15.8-203.nobara.fc41.x86_64.rpm \
+  https://download.copr.fedorainfracloud.org/results/playtron/gaming/fedora-41-x86_64/09410114-kernel/kernel-modules-6.15.8-203.nobara.fc41.x86_64.rpm
+# Rebuild NVIDIA drivers.
+RUN cp -r /etc/pam.d /etc/pam.d.bak; sed -i -r 's/^(session\s+required\s+pam_limits.so)/#\1/' /etc/pam.d/*; \
+  mkdir -p /run/akmods; \
+  for k in $(ls -1 /usr/src/kernels); do \
+    akmods --force --kernels "${k}" --kmod "nvidia" || exit 1; \
+    ls /var/cache/akmods/nvidia/*.failed.log > /dev/null 2>&1 && cat /var/cache/akmods/nvidia/*.failed.log || true; \
+    ls /usr/lib/modules/"${k}"/extra/nvidia/nvidia.ko.xz || exit 1; \
+  done; \
+  rm -rf /run/akmods; \
+  rm -rf /etc/pam.d; mv /etc/pam.d.bak /etc/pam.d;
 
 # Clear cache.
 RUN dnf5 clean all && \
@@ -27,24 +29,9 @@ RUN dnf5 clean all && \
     /boot/.vmlinuz*.hmac \
     /var/cache/*
 
-# Work around for inputplumber service not being enabled
-RUN cd /etc/systemd/system/multi-user.target.wants && ln -s /usr/lib/systemd/system/inputplumber.service .
-
-# Temporary copy of files that have changed since the last unstable release
-COPY rootfs/usr/bin/playtron-factory-reset                              /usr/bin/
-COPY rootfs/usr/bin/playtronos-systemreport				/usr/bin/
-COPY rootfs/usr/lib/systemd/system-preset/50-playtron.preset		/usr/lib/systemd/system-preset/
-COPY rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml	/usr/share/inputplumber/devices/
-
-# Configure SELinux.
-RUN mkdir -p /usr/share/selinux/playtron-modules
-COPY rootfs/usr/share/selinux/playtron-modules/dontaudit-powerprofiles_t-passwd_file_t.te	/usr/share/selinux/playtron-modules/
-RUN cd /usr/share/selinux/playtron-modules/ && checkmodule -M -m -o dontaudit-powerprofiles_t-passwd_file_t.mod dontaudit-powerprofiles_t-passwd_file_t.te && semodule_package -o dontaudit-powerprofiles_t-passwd_file_t.pp -m dontaudit-powerprofiles_t-passwd_file_t.mod && semodule -i ./*.pp && rm -f ./*.mod ./*.pp
-COPY rootfs/usr/share/selinux/playtron-modules/systemd_timedated_t-etc_t-lnk_file.te	/usr/share/selinux/playtron-modules/
-RUN cd /usr/share/selinux/playtron-modules/ && checkmodule -M -m -o systemd_timedated_t-etc_t-lnk_file.mod systemd_timedated_t-etc_t-lnk_file.te && semodule_package -o systemd_timedated_t-etc_t-lnk_file.pp -m systemd_timedated_t-etc_t-lnk_file.mod && semodule -i ./*.pp && rm -f ./*.mod ./*.pp
-COPY rootfs/usr/lib/systemd/system/restorecon-bootc.service	/usr/lib/systemd/system/
-COPY rootfs/usr/bin/restorecon-bootc	/usr/bin/
-RUN sed -E -i 's/SELINUX=.+/SELINUX=enforcing/g' /etc/sysconfig/selinux && systemctl enable restorecon-bootc.service
+# Build initramfs
+RUN KERNEL=$(echo /lib/modules/*/vmlinuz | cut -d'/' -f4) \
+  && dracut --reproducible -v --omit-drivers nouveau --add 'ostree' -f --no-hostonly --kver ${KERNEL} /lib/modules/${KERNEL}/initramfs.img
 
 # View final packages.
 RUN rpm -qa | sort


### PR DESCRIPTION
We want to do a new stable build (1.0.1) with only the kernel updated.

Removed re-install of all other packages to:
a) reduce total container size
b) avoid failures due to older package versions likely not being available anymore

Similarly, removed unnecessary file copies.