### PR TITLE
fix(CI): publishes hashes to new backend

### DIFF
--- a/.github/workflows/container-build-stable.yaml
+++ b/.github/workflows/container-build-stable.yaml
@@ -94,3 +94,11 @@ jobs:
                    "release": "${{ env.TAG }}",
                    "assetName": "playtron-gameos-sha256sum.txt"
                }' | grep -i error; then exit 1; fi
+      - name: Notify the backend C about the new release
+        run: |
+          if curl -X POST "${{ secrets.URL_ENDPOINT_HASHES_C }}" \
+               -H "Content-Type: application/json" \
+               --data '{
+                   "release": "${{ env.TAG }}",
+                   "assetName": "playtron-gameos-sha256sum.txt"
+               }' | grep -i error; then exit 1; fi

--- a/.github/workflows/container-build.yaml
+++ b/.github/workflows/container-build.yaml
@@ -107,3 +107,11 @@ jobs:
                    "release": "${{ env.TAG }}",
                    "assetName": "playtron-gameos-sha256sum.txt"
                }' | grep -i error; then exit 1; fi
+      - name: Notify the backend C about the new release
+        run: |
+          if curl -X POST "${{ secrets.URL_ENDPOINT_HASHES_C }}" \
+               -H "Content-Type: application/json" \
+               --data '{
+                   "release": "${{ env.TAG }}",
+                   "assetName": "playtron-gameos-sha256sum.txt"
+               }' | grep -i error; then exit 1; fi


### PR DESCRIPTION
This change adds publishing the OS hashes to an extra backend. The `URL_ENDPOINT_HASHES_C` secret will need to be added to the repo in order for this to work.