### PR TITLE
feat(inputplumber): enable meta key

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -54,7 +54,9 @@ RUN cd /etc/systemd/system/multi-user.target.wants && ln -s /usr/lib/systemd/sys
 COPY rootfs/usr/bin/playtron-factory-reset                              /usr/bin/
 COPY rootfs/usr/bin/playtronos-systemreport				/usr/bin/
 COPY rootfs/usr/lib/systemd/system-preset/50-playtron.preset		/usr/lib/systemd/system-preset/
+COPY rootfs/usr/share/inputplumber/capability_maps/kbd-meta.yaml	/usr/share/inputplumber/capability_maps/
 COPY rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml	/usr/share/inputplumber/devices/
+COPY rootfs/usr/share/inputplumber/devices/60-keyboard-meta.yaml	/usr/share/inputplumber/devices/
 COPY rootfs/usr/lib/udev/hwdb.d/60-powerstation-autostart.hwdb		/usr/lib/udev/hwdb.d/
 COPY rootfs/usr/lib/udev/rules.d/90-powerstation-autostart.rules	/usr/lib/udev/rules.d/
 

--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -282,6 +282,7 @@ COPY rootfs/usr/lib/udev/rules.d/50-suiplay0x1.rules					/usr/lib/udev/rules.d/
 COPY rootfs/usr/lib/udev/rules.d/50-block-scheduler.rules				/usr/lib/udev/rules.d/
 
 # InputPlumber configuration
+COPY rootfs/usr/share/inputplumber/capability_maps/kbd-meta.yaml			/usr/share/inputplumber/capability_maps/
 COPY rootfs/usr/share/inputplumber/capability_maps/playtron_ayaneo_type7.yaml		/usr/share/inputplumber/capability_maps/
 COPY rootfs/usr/share/inputplumber/devices/24-playtron-ayaneo_2s_v2.yaml		/usr/share/inputplumber/devices/
 COPY rootfs/usr/share/inputplumber/devices/24-playtron-suiplay0x1_v2.yaml		/usr/share/inputplumber/devices/
@@ -295,6 +296,7 @@ COPY rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally_x.yaml			/usr/sh
 COPY rootfs/usr/share/inputplumber/devices/25-playtron-rog_ally.yaml			/usr/share/inputplumber/devices/
 COPY rootfs/usr/share/inputplumber/devices/25-playtron-steam_deck.yaml			/usr/share/inputplumber/devices/
 COPY rootfs/usr/share/inputplumber/devices/25-playtron-suiplay0x1.yaml			/usr/share/inputplumber/devices/
+COPY rootfs/usr/share/inputplumber/devices/60-keyboard-meta.yaml			/usr/share/inputplumber/devices/
 
 # PipeWire configuration for RNNoise
 COPY rootfs/usr/share/pipewire/pipewire.conf.d/pipewire-rnnoise.conf			/usr/share/pipewire/pipewire.conf.d/

--- a/rootfs/usr/share/inputplumber/capability_maps/kbd-meta.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/kbd-meta.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: Keyboard Meta Type 1
+
+# Unique identifier of the capability mapping
+id: kbd-meta1
+
+# List of mapped events that are activated by a specific set of activation keys.
+mapping:
+  - name: KeyLeftMeta to Guide
+    source_events:
+      - keyboard: KeyLeftMeta
+    target_event:
+      dbus: ui_guide
+  - name: KeyRightMeta to Guide
+    source_events:
+      - keyboard: KeyRightMeta
+    target_event:
+      dbus: ui_guide
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/60-keyboard-meta.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-keyboard-meta.yaml
@@ -1,0 +1,50 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Keyboard Meta
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: keyboard
+    unique: false
+    passthrough: true
+    udev:
+      properties:
+        - name: ID_INPUT_KEYBOARD
+          value: "1"
+      subsystem: input
+      sys_name: "event*"
+    # Exclude all input except a few keys
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyRightMeta
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices: []
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: kbd-meta1


### PR DESCRIPTION
to be used as a Guide button for accessing the Quick Access Menu (QAM) and going back to the home screen using a keyboard.

This depends on Grid PR 1555.