### PR TITLE
feat(System Report): add output of uptime command

### DIFF
--- a/rootfs/usr/bin/playtronos-systemreport
+++ b/rootfs/usr/bin/playtronos-systemreport
@@ -112,6 +112,7 @@ fi
 if [[ " ${reports[*]} " =~ "process" ]]; then
   echo -e "  Collecting ${RED}process${ENDCOLOR} report..."
   ps afux >"${REPORT_DIR}/processes.out"
+  uptime >"${REPORT_DIR}/uptime.out"
 fi
 
 # Input


### PR DESCRIPTION
This change adds the output of the `uptime` command to include uptime, system load, etc.