### PR TITLE
update install target filesystem uuids to fix reinstall

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,10 @@ data = "GRID_INSTALL_MODE=1"
 [[customizations.files]]
 path = "/etc/systemd/system/resize-root-file-system.service"
 
+# disable media automount
+[[customizations.files]]
+path = "/etc/udev/rules.d/99-media-automount.rules"
+
 # disable qcom_q6v5_pas to allow installer to boot from usb device on X13s
 # NOTE: this prevents audio from working on the X13s
 [[customizations.files]]

--- a/rootfs/usr/libexec/playtron/os-install
+++ b/rootfs/usr/libexec/playtron/os-install
@@ -5,11 +5,19 @@ if [ $EUID -ne 0 ]; then
 	exit 1
 fi
 
+set -x
+set -e
+
 
 function disable_install_mode {
 	rm -rf etc/environment.d
 	rm -f etc/systemd/system/resize-root-file-system.service
+	rm -f etc/udev/rules.d/99-media-automount.rules
 	rm -f etc/modprobe.d/playtron-installer.conf
+}
+
+function get_uuid {
+	blkid $1 | grep -oP ' UUID="[^"]*"' | sed 's/ UUID="\(.*\)"/\1/'
 }
 
 OS_NAME="Playtron GameOS"
@@ -17,7 +25,7 @@ RAW_DISK_SIZE=20G
 SOURCE_DISK=$1
 TARGET_DISK=$2
 
-umount ${TARGET_DISK}*
+umount ${TARGET_DISK}* || true
 
 pv ${SOURCE_DISK} --output ${TARGET_DISK} --size ${RAW_DISK_SIZE} --stop-at-size --numeric 2>&1
 
@@ -38,12 +46,63 @@ if [ "$(uname -m)" == "x86_64" ]; then
 	ROOT_PART=4
 fi
 
+
+# get current UUIDs
+old_efi_uuid=$(get_uuid ${TARGET_DISK}*${EFI_PART})
+old_boot_uuid=$(get_uuid ${TARGET_DISK}*${BOOT_PART})
+old_root_uuid=$(get_uuid ${TARGET_DISK}*${ROOT_PART})
+
+# regenerate UUIDs
+fatlabel --volume-id --reset ${TARGET_DISK}*${EFI_PART}
+tune2fs -U random ${TARGET_DISK}*${BOOT_PART}
+yes | btrfstune -f -u ${TARGET_DISK}*${ROOT_PART}
+
+# get new UUIDs
+new_efi_uuid=$(get_uuid ${TARGET_DISK}*${EFI_PART})
+new_boot_uuid=$(get_uuid ${TARGET_DISK}*${BOOT_PART})
+new_root_uuid=$(get_uuid ${TARGET_DISK}*${ROOT_PART})
+
+
+# update efi filesystem
+mkdir -p /tmp/playtron-install-target-efi
+mount  ${TARGET_DISK}*${EFI_PART} /tmp/playtron-install-target-efi
+pushd  /tmp/playtron-install-target-efi
+
+# update UUID references
+sed -i -e "s/${old_boot_uuid}/${new_boot_uuid}/" EFI/fedora/bootuuid.cfg
+
+popd
+sync
+umount ${TARGET_DISK}*${EFI_PART}
+
+
+# update boot filesystem
+mkdir -p /tmp/playtron-install-target-boot
+mount  ${TARGET_DISK}*${BOOT_PART} /tmp/playtron-install-target-boot
+pushd  /tmp/playtron-install-target-boot
+
+# update UUID references
+sed -i -e "s/${old_boot_uuid}/${new_boot_uuid}/" grub2/bootuuid.cfg
+sed -i -e "s/${old_boot_uuid}/${new_boot_uuid}/" loader.1/entries/ostree-1.conf
+sed -i -e "s/${old_root_uuid}/${new_root_uuid}/" loader.1/entries/ostree-1.conf
+
+popd
+sync
+umount ${TARGET_DISK}*${BOOT_PART}
+
+
 # update root filesystem
 mkdir -p /tmp/playtron-install-target-root
 mount  ${TARGET_DISK}*${ROOT_PART} /tmp/playtron-install-target-root
 pushd /tmp/playtron-install-target-root/root/ostree/deploy/default/deploy/*.0
 
 disable_install_mode
+
+# update UUID references
+sed -i -e "s/${old_boot_uuid}/${new_boot_uuid}/" etc/fstab
+sed -i -e "s/${old_efi_uuid}/${new_efi_uuid}/" etc/systemd/system/boot-efi.mount
+sed -i -e "s/${old_root_uuid}/${new_root_uuid}/" etc/systemd/system/-.mount
+sed -i -e "s/${old_boot_uuid}/${new_boot_uuid}/" etc/systemd/system/boot.mount
 
 popd
 sync


### PR DESCRIPTION
This fixes not being able to boot the installer when the system was previously installed with the same installer.

The installer clones the disk, along with filesystem UUIDs. This causes the installer and the installed system to share filesystem UUIDs, so when booting the system becomes confused and may boot with the wrong disk, or partitions.

The solution is to update the UUIDs on the target disk after the disk clone operation. This also requires updating all references to the UUIDs on the filesystem.

Also, it is probably not strictly required, but at one point I suspected that the automount system was interfering with the UUID update operations, so I disabled automounting in the installer. This is probably a good thing to do in any case.