### PR TITLE
fix(hwctl): set vram to 0 if it is not detected

### DIFF
--- a/rootfs/usr/bin/hwctl
+++ b/rootfs/usr/bin/hwctl
@@ -36,6 +36,9 @@ function system-info {
 	GPU_NAME=$(grep 'OpenGL renderer string:' /tmp/glxinfo.txt | cut -d':' -f2 | sed 's/^ //' | sed 's/ (/\n/' | head -1)
 	GPU_VENDOR=$(grep 'OpenGL vendor string:' /tmp/glxinfo.txt | cut -d':' -f2 | tr -d ' ')
 	VRAM=$(grep "Dedicated video memory:" /tmp/glxinfo.txt | cut -d':' -f2 | sed 's/^ *//' | tr -d ' MB')
+	if [[ "$VRAM" == "" ]]; then
+		VRAM="0"
+	fi
 
 	# Operating system
 	source /etc/os-release


### PR DESCRIPTION
This change fixes issues with `hwctl` where it will output invalid JSON if the vram is not detected.

**Log**
```bash
ERROR system::device::routes::device_info_get  Error fetching device info, err:Error("expected value", line: 14, column: 12)
```

**HWCTL output**

```json
{
        ...
        "gpuName": "Mesa Intel(R) Graphics",
        "vramMB": ,
        "osName": "GameOS",
        "osVersion": "1.1.5.2",
        ...
}
```