### PR TITLE
Use static MAC address

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -63,6 +63,7 @@ COPY rootfs/usr/lib/udev/hwdb.d/60-powerstation-autostart.hwdb		/usr/lib/udev/hw
 COPY rootfs/usr/lib/udev/rules.d/90-powerstation-autostart.rules	/usr/lib/udev/rules.d/
 COPY rootfs/usr/share/plymouth/themes/spinner/watermark.png		/usr/share/plymouth/themes/spinner/
 COPY rootfs/usr/share/polkit-1/rules.d/50-one.playtron.playtronos-systemreport.rules /usr/share/polkit-1/rules.d/
+COPY rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf		/usr/lib/NetworkManager/conf.d/
 
 # Ensure services are enabled according to presets
 RUN systemctl preset-all

--- a/rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf
+++ b/rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf
@@ -1,5 +1,10 @@
-[device]
+# Use the static device MAC address for more reliable connections.
+# https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/
+[device-mac-static]
 wifi.scan-rand-mac-address=no
+[connection-mac-static]
+wifi.cloned-mac-address=permanent
+ethernet.cloned-mac-address=permanent
 
 # Enable connectivity checking for NetworkManager.
 # See `man NetworkManager.conf`.


### PR DESCRIPTION
for all connection types in NetworkManager (not just Wi-Fi scanning).