### PR TITLE
 fix(hwctl): add number validation for system-info subcommand 

### DIFF
--- a/rootfs/usr/bin/hwctl
+++ b/rootfs/usr/bin/hwctl
@@ -36,9 +36,6 @@ function system-info {
 	GPU_NAME=$(grep 'OpenGL renderer string:' /tmp/glxinfo.txt | cut -d':' -f2 | sed 's/^ //' | sed 's/ (/\n/' | head -1)
 	GPU_VENDOR=$(grep 'OpenGL vendor string:' /tmp/glxinfo.txt | cut -d':' -f2 | tr -d ' ')
 	VRAM=$(grep "Dedicated video memory:" /tmp/glxinfo.txt | cut -d':' -f2 | sed 's/^ *//' | tr -d ' MB')
-	if [[ "$VRAM" == "" ]]; then
-		VRAM="0"
-	fi
 
 	# Operating system
 	source /etc/os-release
@@ -75,8 +72,8 @@ function system-info {
 
 	if [ "$1" == "extended" ]; then
 		echo -n "
-	\"resolutionWidth\": $RES_WIDTH,
-	\"resolutionHeight\": $RES_HEIGHT,"
+	\"resolutionWidth\": $(ensure_number $RES_WIDTH),
+	\"resolutionHeight\": $(ensure_number $RES_HEIGHT),"
 	fi
 
 	echo "
@@ -86,12 +83,12 @@ function system-info {
 	\"cpuArchitecture\": \"$CPU_ARCH\",
 	\"cpuVendor\": \"$CPU_VENDOR\",
 	\"cpuName\": \"$CPU_NAME\",
-	\"cpuNumCores\": $CPU_PHYSICAL,
-	\"cpuSpeedMHZ\": $CPU_SPEED,
-	\"ramTotalMB\": $TOTAL_RAM,
+	\"cpuNumCores\": $(ensure_number $CPU_PHYSICAL),
+	\"cpuSpeedMHZ\": $(ensure_number $CPU_SPEED),
+	\"ramTotalMB\": $(ensure_number $TOTAL_RAM),
 	\"gpuVendor\": \"$GPU_VENDOR\",
 	\"gpuName\": \"$GPU_NAME\",
-	\"vramMB\": $VRAM,
+	\"vramMB\": $(ensure_number $VRAM),
 	\"osName\": \"$OS_NAME\",
 	\"osVersion\": \"$OS_VERSION\",
 	\"autotestVersion\": \"$AUTOTEST_VERSION\",
@@ -108,7 +105,7 @@ function system-info {
 		        free=$(echo "$line" | cut -d' ' -f3 | tr -d 'M')
 		        echo "		},
 		{
-			\"totalMB\": $total,
+			\"totalMB\": $(ensure_number $total),
 			\"primary\": false"
 		done <<< "$secondary_storage_devices"
 	fi
@@ -409,6 +406,17 @@ function validate_value {
 	else
 		return 0
 	fi
+}
+
+function ensure_number {
+	value=$1
+	re='^[+-]?[0-9]+([.][0-9]+)?$'
+	if ! [[ "$value" =~ $re ]]; then
+		echo "0"
+		exit 1
+	fi
+	echo "$value"
+	exit 0
 }
 
 function audio_common {

--- a/rootfs/usr/bin/hwctl
+++ b/rootfs/usr/bin/hwctl
@@ -20,8 +20,8 @@ function system-info {
 	CPU_VENDOR=$(grep 'vendor_id' /tmp/cpuinfo.txt | head -n1 | cut -d':' -f2 | sed 's/^ //')
 	CPU_NAME=$(grep 'model name' /tmp/cpuinfo.txt | head -n1 | cut -d':' -f2 | sed 's/^ //')
 	CPU_PHYSICAL=$(grep 'cpu cores' /tmp/cpuinfo.txt | head -n1 | cut -d':' -f2 | tr -d ' ')
-	CPU_SPEED="$(lscpu | grep 'CPU max MHz' | cut -d':' -f2 | tr -d ' ' | cut -d'.' -f1)"
-	CPU_ARCH="$(lscpu | grep 'Architecture:' | cut -d':' -f2 | tr -d ' ')"
+	CPU_SPEED="$(lscpu | grep 'CPU max MHz' | head -n 1 | cut -d':' -f2 | tr -d ' ' | cut -d'.' -f1)"
+	CPU_ARCH="$(lscpu | grep 'Architecture:' | head -n 1 | cut -d':' -f2 | tr -d ' ')"
 
 	# Memory
 	TOTAL_RAM=$(grep MemTotal /proc/meminfo | tr -s ' ' | cut -d' ' -f2)


### PR DESCRIPTION
This change adds number validation to `hwctl` to ensure that it will output valid, parseable JSON. Previously, if a value was not found, it would output invalid data:

```json
{
        ...
        "gpuName": "Mesa Intel(R) Graphics",
        "vramMB": ,
        "osName": "GameOS",
        ...
}
```

Additionally, this change also fixes an issue if two CPU speeds are reported (like on the X13S):

```bash
$ lscpu | grep 'CPU max MHz'
CPU max MHz:                             2438.3999
CPU max MHz:                             2995.2000
```

which would result in the following invalid JSON data:

```json
{
        ...
        "cpuNumCores": ,
        "cpuSpeedMHZ": 2438
2995,
        "ramTotalMB": 15321,
        ...
}
```