### PR TITLE
Stable 1.1

### DIFF
--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -63,6 +63,7 @@ COPY rootfs/usr/lib/udev/hwdb.d/60-powerstation-autostart.hwdb		/usr/lib/udev/hw
 COPY rootfs/usr/lib/udev/rules.d/90-powerstation-autostart.rules	/usr/lib/udev/rules.d/
 COPY rootfs/usr/share/plymouth/themes/spinner/watermark.png		/usr/share/plymouth/themes/spinner/
 COPY rootfs/usr/share/polkit-1/rules.d/50-one.playtron.playtronos-systemreport.rules /usr/share/polkit-1/rules.d/
+COPY rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf		/usr/lib/NetworkManager/conf.d/
 
 # Ensure services are enabled according to presets
 RUN systemctl preset-all

--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -28,18 +28,18 @@ RUN dnf5 -y upgrade \
   gamescope-dbus-1.10.4-1 \
   gamescope-session-0.1.0+319-1.fc41 \
   gamescope-session-playtron-0.4.1-1.fc41 \
-  grid-1.20.0-1.fc40 \
-  inputplumber-0.63.1-0.fc41 \
+  grid-1.20.1-1.fc40 \
+  inputplumber-0.64.0-0.fc41 \
   legendary-0.20.41-1.playtron \
   libpact-0.3.0-1 \
   libplaytron-0.4.0-1 \
   powerstation-0.7.0-1 \
-  playserve-1.11.3-1 \
-  playtron-plugin-local-1.3.3-1 \
+  playserve-1.12.0-1 \
+  playtron-plugin-local-1.4.0-1 \
   reaper-0.1.0-2.fc41 \
   tzupdate-3.1.0-1.fc41 \
   udev-media-automount-0.1.0+71-1.fc41 \
-  SteamBus-1.25.6-1.fc41 \
+  SteamBus-1.26.0-1.fc41 \
   xdg-desktop-portal-openuri-1.0.1-1.fc41
 
 # Clear cache.

--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -29,7 +29,7 @@ RUN dnf5 -y upgrade \
   gamescope-session-0.1.0+319-1.fc41 \
   gamescope-session-playtron-0.4.1-1.fc41 \
   grid-1.21.0-1.fc40 \
-  inputplumber-0.64.0-0.fc41 \
+  inputplumber-0.66.0-0.fc41 \
   legendary-0.20.41-1.playtron \
   libpact-0.3.0-1 \
   libplaytron-0.4.0-1 \

--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -28,13 +28,13 @@ RUN dnf5 -y upgrade \
   gamescope-dbus-1.10.4-1 \
   gamescope-session-0.1.0+319-1.fc41 \
   gamescope-session-playtron-0.4.1-1.fc41 \
-  grid-1.20.1-1.fc40 \
+  grid-1.21.0-1.fc40 \
   inputplumber-0.64.0-0.fc41 \
   legendary-0.20.41-1.playtron \
   libpact-0.3.0-1 \
   libplaytron-0.4.0-1 \
   powerstation-0.7.0-1 \
-  playserve-1.12.0-1 \
+  playserve-1.13.0-1 \
   playtron-plugin-local-1.4.0-1 \
   reaper-0.1.0-2.fc41 \
   tzupdate-3.1.0-1.fc41 \

--- a/containerfiles/stable
+++ b/containerfiles/stable
@@ -28,7 +28,7 @@ RUN dnf5 -y upgrade \
   gamescope-dbus-1.10.4-1 \
   gamescope-session-0.1.0+319-1.fc41 \
   gamescope-session-playtron-0.4.1-1.fc41 \
-  grid-1.19.3-1.fc40 \
+  grid-1.20.0-1.fc40 \
   inputplumber-0.63.1-0.fc41 \
   legendary-0.20.41-1.playtron \
   libpact-0.3.0-1 \

--- a/rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf
+++ b/rootfs/usr/lib/NetworkManager/conf.d/50-playtron.conf
@@ -1,5 +1,10 @@
-[device]
+# Use the static device MAC address for more reliable connections.
+# https://blogs.gnome.org/thaller/2016/08/26/mac-address-spoofing-in-networkmanager-1-4-0/
+[device-mac-static]
 wifi.scan-rand-mac-address=no
+[connection-mac-static]
+wifi.cloned-mac-address=permanent
+ethernet.cloned-mac-address=permanent
 
 # Enable connectivity checking for NetworkManager.
 # See `man NetworkManager.conf`.


### PR DESCRIPTION
Final sync of the `stable-1.1` branch into `main` before we switch to developing in `main` again.

This branching strategy made a bit more sense during the beta (pre-1.0) builds but not so far in the the stable (1.0) builds. We've mostly been in bug fixing mode. Backports don't always make sense, either. If needed, we can use different `Containerfile.${VERSION}` file instead.

There is some drift where changes have gone into `main` but have not gone into `stable-1.1`. This PR helps to align us again.