### PR TITLE
feat(containerfiles): pin 'fedora-bootc:43'

### DIFF
--- a/containerfiles/unstable
+++ b/containerfiles/unstable
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora-bootc:43
+FROM quay.io/playtron/fedora-bootc:43-20260407-multiarch
 
 ARG TARGETARCH
 


### PR DESCRIPTION
to a static version. The upstream container is rebuilt and reuploaded daily. This helps to avoid invalidating the very first layer of cache.